### PR TITLE
Semantic Versioningの実装

### DIFF
--- a/Class/SemVer.ps1
+++ b/Class/SemVer.ps1
@@ -27,6 +27,7 @@ class SemVer :IComparable {
 
     #region <#---- init() ----#>
     Hidden init () {
+        # Add read-only properties
         $Members = $this | Get-Member -Force -MemberType Property -Name '_*'
         ForEach ($Member in $Members) {
             $PublicPropertyName = $Member.Name -replace '_', ''
@@ -246,4 +247,36 @@ class SemVer :IComparable {
 
         return 0
     }
+
+    #region <#---- Equals() override----#>
+    [bool] Equals([object]$object) {
+        $ver = ($object -as [Semver])
+
+        # If parameter is null, return false
+        if ($null -eq $ver) {
+            return $false
+        }
+
+        # Optimization for a common success case.
+        if ([Object]::ReferenceEquals($this, $ver)) {
+            return $true
+        }
+        
+        return (
+            # SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            $this._Major -eq $ver._Major -and `
+                $this._Minor -eq $ver._Minor -and `
+                $this._Patch -eq $ver._Patch -and `
+                $this._Revision -eq $ver._Revision -and `
+                [string]::Equals($this._PreReleaseLabel, $ver._PreReleaseLabel, [System.StringComparison]::Ordinal)
+        )
+    }
+    #endregion <#---- Equals() override----#>
+
+    #region <#---- GetHashCode() override----#>
+    [int] GetHashCode(){
+        return $this.ToString().GetHashCode()
+    }
+    #endregion <#---- GetHashCode() override----#>
+
 }

--- a/Class/SemVer.ps1
+++ b/Class/SemVer.ps1
@@ -1,0 +1,221 @@
+
+class SemVer :IComparable {
+
+    # Major
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$Major
+
+    # Minor
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$Minor = 0
+
+    # Patch
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$Patch = 0
+
+    # Revision
+    [ValidateRange(0, [int]::MaxValue)]
+    [int]$Revision = 0
+
+    # PreReleaseLabel
+    [ValidatePattern('^[.0-9A-Za-z-]*$')]
+    [string]$PreReleaseLabel
+
+    # BuildLabel
+    [ValidatePattern('^[.0-9A-Za-z-]*$')]
+    [string]$BuildLabel
+
+    #region Constructor
+    SemVer([int]$major) {
+        $this.Major = $major
+    }
+
+    SemVer([int]$major, [int]$minor) {
+        $this.Major = $major
+        $this.Minor = $minor
+    }
+
+    SemVer([int]$major, [int]$minor, [int]$patch) {
+        $this.Major = $major
+        $this.Minor = $minor
+        $this.Patch = $patch
+    }
+
+    SemVer([int]$major, [int]$minor, [int]$patch, [int]$revision) {
+        $this.Major = $major
+        $this.Minor = $minor
+        $this.Patch = $patch
+        $this.Revision = $revision
+    }
+
+    SemVer([int]$major, [int]$minor, [int]$patch, [int]$revision, [string]$prerelease, [string]$build) {
+        $this.Major = $major
+        $this.Minor = $minor
+        $this.Patch = $patch
+        $this.Revision = $revision
+        $this.PreReleaseLabel = $prerelease
+        $this.BuildLabel = $build
+    }
+
+    SemVer([version]$version) {
+        $this.Major = if ($version.Major -ge 0) {$version.Major} else {0}
+        $this.Minor = if ($version.Minor -ge 0) {$version.Minor} else {0}
+        $this.Patch = if ($version.Build -ge 0) {$version.Build} else {0}
+        $this.Revision = if ($version.Revision -ge 0) {$version.Revision} else {0}
+    }
+
+    SemVer([string]$string) {
+        $private:semver = [SemVer]::Parse($string)
+        $this.Major = $private:semver.Major
+        $this.Minor = $private:semver.Minor
+        $this.Patch = $private:semver.Patch
+        $this.Revision = $private:semver.Revision
+        $this.PreReleaseLabel = $private:semver.PreReleaseLabel
+        $this.BuildLabel = $private:semver.BuildLabel
+    }
+    #endregion Constructor
+
+    <#---- ToString() ----#>
+    [String] ToString() {
+        [string]$Ret = (($this.Major, $this.Minor, $this.Patch) -join '.')
+
+        if ($this.Revision) {
+            $Ret += ('.{0}' -f $this.Revision)
+        }
+        if ($this.PreReleaseLabel) {
+            $Ret += ('-{0}' -f $this.PreReleaseLabel)
+        }
+        if ($this.BuildLabel) {
+            $Ret += ('+{0}' -f $this.BuildLabel)
+        }
+
+        return $Ret
+    }
+
+    <#---- Parse() ----#>
+    static [SemVer] Parse([string]$string) {
+        # split major.minor.patch
+        $local:numbers = $string.split('-')[0].split('+')[0].split('.')
+        $tMajor = if ([int]::TryParse($numbers[0], [ref]$null)) {if (($n = [int]::Parse($numbers[0])) -ge 0) {$n} else {0}} else {throw [System.FormatException]}
+        $tMinor = if (-not $numbers[1]) {0} elseif ([int]::TryParse($numbers[1], [ref]$null)) {if (($n = [int]::Parse($numbers[1])) -ge 0) {$n} else {0}} else {throw [System.FormatException]}
+        $tPatch = if (-not $numbers[2]) {0} elseif ([int]::TryParse($numbers[2], [ref]$null)) {if (($n = [int]::Parse($numbers[2])) -ge 0) {$n} else {0}} else {throw [System.FormatException]}
+        $tRevision = if (-not $numbers[3]) {0} elseif ([int]::TryParse($numbers[3], [ref]$null)) {if (($n = [int]::Parse($numbers[3])) -ge 0) {$n} else {0}} else {throw [System.FormatException]}
+        
+        # split prelease+buildmeta
+        $local:prerelease = if (($i = $string.IndexOf('-')) -ge 1) {$string.Substring($i + 1)} #behind from hyphen
+        $local:build = if (($j = $string.IndexOf('+')) -ge 1) {$string.Substring($j + 1)} #behind from plus
+
+        if ($local:prerelease.length -gt $local:build.length) {
+            if (-not [string]::IsNullOrEmpty($local:prerelease)) {
+                $private:tmp = $local:prerelease.split('+')
+                $tPreReleaseLabel = ([string]$private:tmp[0]).Trim()
+                $tBuildLabel = ([string]$private:tmp[1]).Trim()
+            }
+        }
+        else {
+            if (-not [string]::IsNullOrEmpty($local:build)) {
+                $tBuildLabel = ([string]$local:build).Trim()
+            }
+        }
+
+        return [SemVer]::new($tMajor, $tMinor, $tPatch, $tRevision, $tPreReleaseLabel, $tBuildLabel)
+    }
+
+    <#---- TryParse() ----#>
+    static [bool] TryParse([string]$string, [ref]$ref) {
+        try {
+            $private:tmp = [SemVer]::Parse($string)
+            $ref.Value = $private:tmp
+            return $true
+        }
+        catch {
+            return $false
+        }
+    }
+
+    <#---- CompareTo() ----#>
+    [int] CompareTo([object]$semver) {
+        $semver = [SemVer]$semver
+
+        #Compare Major
+        if ($this.Major -ne $semver.Major) {
+            if ($this.Major -gt $semver.Major) {
+                return 1
+            }
+            else {
+                return -1
+            }
+        }
+
+        #Compare Minor
+        elseif ($this.Minor -ne $semver.Minor) {
+            if ($this.Minor -gt $semver.Minor) {
+                return 1
+            }
+            else {
+                return -1
+            }
+        }
+
+        #Compare Patch
+        elseif ($this.Patch -ne $semver.Patch) {
+            if ($this.Patch -gt $semver.Patch) {
+                return 1
+            }
+            else {
+                return -1
+            }
+        }
+
+        #Compare Revision
+        elseif ($this.Revision -ne $semver.Revision) {
+            if ($this.Revision -gt $semver.Revision) {
+                return 1
+            }
+            else {
+                return -1
+            }
+        }
+
+        #Compare Prerelease
+        elseif ($this.PreReleaseLabel -or $semver.PreReleaseLabel) {
+            if ((-not $this.PreReleaseLabel) -and $semver.PreReleaseLabel) {
+                return 1
+            }
+            elseif ($this.PreReleaseLabel -and (-not $semver.PreReleaseLabel)) {
+                return -1
+            }
+            elseif ($this.PreReleaseLabel -eq $semver.PreReleaseLabel) {
+                return 0
+            }
+            else {
+                $identifierMyself = @($this.PreReleaseLabel.split('.'))
+                $identifierTarget = @($semver.PreReleaseLabel.split('.'))
+                
+                for ($i = 0; $i -le $identifierMyself.Count; $i++) {
+                    if ($identifierMyself[$i] -eq $identifierTarget[$i]) {
+                        continue
+                    }
+
+                    if ($identifierMyself -and (-not $identifierTarget[$i])) {
+                        return 1
+                    }
+                    elseif ((-not $identifierMyself) -and $identifierTarget[$i]) {
+                        return -1
+                    }
+
+                    else {
+                        if ([string]$identifierMyself[$i] -gt [string]$identifierTarget[$i]) {
+                            return 1
+                        }
+                        else {
+                            return -1
+                        }
+                    }
+                }
+            }
+        }
+
+        return 0
+    }
+}

--- a/Class/SemVer.ps1
+++ b/Class/SemVer.ps1
@@ -25,6 +25,13 @@ class SemVer :IComparable {
     [ValidatePattern('^[.0-9A-Za-z-]*$')]
     Hidden [string]$_BuildLabel
 
+    # static member Max
+    static [SemVer]$Max = [SemVer]::new([int]::MaxValue, [int]::MaxValue, [int]::MaxValue, [int]::MaxValue)
+    
+    # static member Min
+    static [SemVer]$Min = [SemVer]::new(0)
+
+
     #region <#---- init() ----#>
     Hidden init () {
         # Add read-only properties

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -23,25 +23,32 @@ Class SemVerRange {
     .DESCRIPTION
     The minimum version of range
     #>
-    [SemVer]$MinimumVersion
+    [SemVer]$MinimumVersion = '0.0.0'
 
     <#
     .DESCRIPTION
     The maximum version of range
     #>
-    [SemVer]$MaximumVersion
+    [SemVer]$MaximumVersion = '0.0.0'
 
     <#
     .DESCRIPTION
     Expression string of range
     #>
-    [string]$Expression
+    [string]$Expression = '<0.0.0'
 
     # private properties
-    Hidden [bool]$_IncludeMaximum = $true
-    Hidden [bool]$_IncludeMinimum = $true
+    Hidden [bool]$_IncludeMaximum = $false
+    Hidden [bool]$_IncludeMinimum = $false
 
     #region <-- Constructor -->
+
+    <#
+    .SYNOPSIS
+    Construct a new range that not matched any of versions (<0.0.0)
+    #>
+    SemVerRange() {}
+
 
     <#
     .SYNOPSIS

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -1,0 +1,510 @@
+
+enum Operator {
+    Equal = 0
+    LessThan
+    LessEqual
+    MoreThan
+    MoreEqual
+}
+
+<#
+.SYNOPSIS
+This class express a range of SemVer
+
+.DESCRIPTION
+The SemVerRange class express a range of SemVer,
+allowing you to parse range expression string,
+and allowing you to test a SemVer satisfies the range or not.
+
+.EXAMPLE
+$Range = [SemVerRange]::new('1.2.x')
+$Range.IsSatisfied('1.2.0')  # =>true
+$Range.IsSatisfied('1.3.0')  # =>false
+
+.NOTES
+You can refer to the range syntax in the document of npm-semver.
+(Some advanced syntax is not implemented yet, sorry.)
+https://docs.npmjs.com/misc/semver
+#>
+Class SemVerRange {
+
+    <#
+    .DESCRIPTION
+    The minimum version of range
+    #>
+    [SemVer]$MinimumVersion
+
+    <#
+    .DESCRIPTION
+    The maximum version of range
+    #>
+    [SemVer]$MaximumVersion
+
+    <#
+    .DESCRIPTION
+    Expression string of range
+    #>
+    [string]$Expression
+
+    # private properties
+    Hidden [Operator]$_GraterOperator = [Operator]::MoreEqual
+    Hidden [Operator]$_LowerOperator = [Operator]::LessEqual
+
+    #region <-- Constructor -->
+
+    <#
+    .SYNOPSIS
+    Construct a new range from a min & max version
+
+    .PARAMETER minimum
+    The minimum version of a range. (>=min)
+
+    .PARAMETER maximum
+    The maximum version of a range. (<=max)
+    #>
+    SemVerRange([SemVer]$minimum, [SemVer]$maximum) {
+        $this.MaximumVersion = $maximum
+        $this.MinimumVersion = $minimum
+        $this._GraterOperator = [Operator]::MoreEqual
+        $this._LowerOperator = [Operator]::LessEqual
+
+        $this.Expression = ('>={0} <={1}' -f [string]$minimum, [string]$maximum)
+    }
+
+
+    <#
+    .SYNOPSIS
+    Construct a new range from range expression string
+
+    .PARAMETER expression
+    The range expression string.
+
+    .EXCEPTION [System.ArgumentException]
+    Thrown when the range expression is invalid or unsupported.
+    #>
+    SemVerRange([string]$expression) {
+        $isError = $false
+        
+        # All
+        if (($expression -eq '') -or ($expression -eq '*')) {
+            #empty or asterisk match all versions
+            $this.Expression = '>=0.0.0'
+        }
+
+        # X-Ranges (1.x, 1.2.x, 1.2.*)
+        elseif ($expression -match '^\d+(\.\d+)?\.[x\*]') {
+            $regex = ([RegEx]::new('\d+(?=\.[x\*])', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase))
+
+            $this._RangeHelper($expression, $regex)
+        }
+
+        # Partial range (1, 1.2)
+        elseif ($expression -match '^\d+(\.\d+)?$') {
+            $newexp = $expression + '.x'    # treat as X-Range
+            $regex = ([RegEx]::new('\d+(?=\.x)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase))
+
+            try {
+                $this._RangeHelper($newexp, $regex)
+            }
+            catch [System.ArgumentException] {
+                $isError = $true
+            }
+        }
+
+        # Tilde Ranges
+        elseif ($expression.StartsWith('~')) {
+            # Tilde pattern 1 (~1, ~1.2)
+            if ($expression -match '^~\d+(\.\d+)?$') {
+                $newexp = $expression.Substring(1) + '.x'    # treat as X-Range
+                $regex = ([RegEx]::new('\d+(?=\.x)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase))
+
+                try {
+                    $this._RangeHelper($newexp, $regex)
+                }
+                catch [System.ArgumentException] {
+                    $isError = $true
+                }
+            }
+            # Tilde pattern 2 (~1.2.3, ~1.2.3-beta)
+            else {
+                try {
+                    [SemVer]$min = [SemVer]::Parse($expression.Substring(1))
+                    [SemVer]$max = [SemVer]::new($min.Major, $min.Minor + 1, 0)
+
+                    $this.MaximumVersion = $max
+                    $this.MinimumVersion = $min
+                    $this._GraterOperator = [Operator]::MoreEqual
+                    $this._LowerOperator = [Operator]::LessThan
+            
+                    $this.Expression = ('>={0} <{1}' -f [string]$min, [string]$max)
+                }
+                catch {
+                    $isError = $true
+                }
+            }
+        }
+
+        # Caret Ranges (^1.2, ^0.2.3)
+        elseif ($expression.StartsWith('^')) {
+            try {
+                $escape = $expression.Substring(1).Split('-')
+                [SemVer]$ver = [SemVer]::Parse([regex]::Replace($escape[0], '[xX\*]', '0'))
+                [SemVer]$newver = $null
+
+                if ($ver.Major -ne 0) {
+                    $newver = [SemVer]::new($ver.Major + 1)
+                }
+                elseif ($ver.Minor -ne 0) {
+                    $newver = [SemVer]::new($ver.Major, $ver.Minor + 1)
+                }
+                elseif ($ver.Patch -ne 0) {
+                    $newver = [SemVer]::new($ver.Major, $ver.Minor, $ver.Patch + 1)
+                }
+                elseif ($ver.Revision -ne 0) {
+                    $newver = [SemVer]::new($ver.Major, $ver.Minor, $ver.Patch, $ver.Revision + 1)
+                }
+                else {
+                    $newver = [SemVer]('0.1.0')
+                }
+
+                $maxSemVer = $newver
+                $minSemVer = [SemVer]::Parse([regex]::Replace($escape[0], '[xX\*]', '0') + '-' + $escape[1])
+                $this.MaximumVersion = $maxSemVer
+                $this.MinimumVersion = $minSemVer
+                $this._GraterOperator = [Operator]::MoreEqual
+                $this._LowerOperator = [Operator]::LessThan
+
+                $this.Expression = ('>={0} <{1}' -f [string]$minSemVer, [string]$maxSemVer)
+            }
+            catch {
+                $isError = $true
+            }
+        }
+        
+        elseif ($expression.StartsWith('>')) {
+            if ($expression.Substring(1).StartsWith('=')) {
+                #Grater equals (e.g. '>=1.2.0'
+                $local:tempVersion = $expression.Substring(2)
+                if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MinimumVersion = [SemVer]::Parse($tempVersion)
+                    $this._GraterOperator = [Operator]::MoreEqual
+                }
+                else {
+                    $isError = $true
+                }
+            }
+            else {
+                #Grater than (e.g. '>1.2.0'
+                $local:tempVersion = $expression.Substring(1)
+                if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MinimumVersion = [SemVer]::Parse($tempVersion)
+                    $this._GraterOperator = [Operator]::MoreThan
+                }
+                else {
+                    $isError = $true
+                }
+            }
+        }
+        elseif ($expression.StartsWith('<')) {
+            if ($expression.Substring(1).StartsWith('=')) {
+                #Less equals (e.g. '<=1.2.0'
+                $local:tempVersion = $expression.Substring(2)
+                if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MaximumVersion = [SemVer]::Parse($tempVersion)
+                    $this._LowerOperator = [Operator]::LessEqual
+                }
+                else {
+                    $isError = $true
+                }
+            }
+            else {
+                #Less than (e.g. '<1.2.0'
+                $local:tempVersion = $expression.Substring(1)
+                if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MaximumVersion = [SemVer]::Parse($tempVersion)
+                    $this._LowerOperator = [Operator]::LessThan
+                }
+                else {
+                    $isError = $true
+                }
+            }
+        }
+
+        # Strict
+        elseif ([SemVer]::TryParse($expression, [ref]$null)) {
+            #Specified strict version (e.g. '1.2.0'
+            $this.MinimumVersion = [SemVer]::Parse($expression)
+            $this.MaximumVersion = $this.MinimumVersion
+            $this._GraterOperator = [Operator]::MoreEqual
+            $this._LowerOperator = [Operator]::LessEqual
+            
+            $this.Expression = [string]$this.MinimumVersion
+        }
+
+        else {
+            $isError = $true
+        }
+
+        if ($isError) {
+            throw [System.ArgumentException]::new(('Invalid range expression: "{0}"' -f $expression))
+        }
+    }
+    #endregion <-- Constructor -->
+
+
+    <#
+    .SYNOPSIS
+    private helper method for X-Range parsing
+    #>
+    #region <-- _RangeHelper() -->
+    Hidden [void] _RangeHelper([string]$expression, [regex]$regex) {
+        $escape = $expression.Split('-')
+
+        $match = $regex.Match($escape[0])
+    
+        $max = $regex.Replace($escape[0], ([int]$match.Value + 1)).Replace('x', '0').Replace('X', '0').Replace('*', '0')
+        $min = $escape[0].Replace('x', '0').Replace('X', '0').Replace('*', '0') + '-' + $escape[1]
+
+        try {
+            $maxSemVer = [SemVer]::Parse($max)
+            $minSemVer = [SemVer]::Parse($min)
+            $this.MaximumVersion = $maxSemVer
+            $this.MinimumVersion = $minSemVer
+            $this._GraterOperator = [Operator]::MoreEqual
+            $this._LowerOperator = [Operator]::LessThan
+
+            $this.Expression = ('>={0} <{1}' -f [string]$minSemVer, [string]$maxSemVer)
+        }
+        catch [System.FormatException] {
+            throw [System.ArgumentException]::new(('Invalid range expression: "{0}"' -f $expression))
+        }
+    }
+    #endregion <-- _RangeHelper() -->
+
+
+    #region <-- IsSatisfied() -->
+
+    <#
+    .SYNOPSIS
+    Test whether the given version satisfies this range.
+
+    .PARAMETER version
+    The version to test
+
+    .RETURN
+    Return true if the version satisfies the range.
+    #>
+    [bool] IsSatisfied([SemVer]$version) {
+        return [SemVerRange]::IsSatisfied($this, $version)
+    }
+
+    
+    <#
+    .SYNOPSIS
+    Test whether the given version satisfies a given range.
+
+    .PARAMETER range
+    The range for test
+
+    .PARAMETER version
+    The version to test
+
+    .RETURN
+    Return true if the version satisfies the range.
+    #>
+    static [bool] IsSatisfied([SemVerRange]$range, [SemVer]$version) {
+
+        $ret = $true
+
+        if ($range.MinimumVersion) {
+            switch ($range._GraterOperator) {
+                MoreEqual {
+                    $ret = $ret -and ($version -ge $range.MinimumVersion)
+                    break
+                }
+
+                MoreThan {
+                    $ret = $ret -and ($version -gt $range.MinimumVersion)
+                    break
+                }
+
+                Default {
+                    throw [System.InvalidOperationException]::new()
+                }
+            }
+        }
+
+        if ($range.MaximumVersion) {
+            switch ($range._LowerOperator) {
+                LessEqual {
+                    $ret = $ret -and ($version -le $range.MaximumVersion)
+                    break
+                }
+
+                LessThan {
+                    $ret = $ret -and ($version -lt $range.MaximumVersion)
+                    break
+                }
+
+                Default {
+                    throw [System.InvalidOperationException]::new()
+                }
+            }
+        }
+
+        return $ret
+    }
+    #endregion <-- IsSatisfied() -->
+
+
+    #region <-- MaxSatisfying() -->
+
+    <#
+    .SYNOPSIS
+    Get the highest version in the list that satisfies this range.
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the highest version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    $Range = [SemVerRange]::new('>1.2.3')
+    $Range.MaxSatisfying(@('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.99'
+    #>
+    [SemVer] MaxSatisfying([SemVer[]]$versions) {
+        return [SemVerRange]::MaxSatisfying($this, $versions)
+    }
+
+
+    <#
+    .SYNOPSIS
+    Get a highest version in the list that satisfies the given range.
+
+    .PARAMETER range
+    The range for test
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the highest version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    [SemVerRange]::MaxSatisfying('>1.2.3', @('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.99'
+    #>
+    static [SemVer] MaxSatisfying([SemVerRange]$range, [SemVer[]]$versions) {
+        $sortedVersions = ($versions | Sort-Object -Descending -Unique)
+
+        foreach ($v in $sortedVersions) {
+            if ($range.IsSatisfied($v)) {
+                return $v
+            }
+        }
+
+        return $null
+    }
+    #endregion <-- MaxSatisfying() -->
+
+
+    #region <-- MinSatisfying() -->
+
+    <#
+    .SYNOPSIS
+    Get the lowest version in the list that satisfies this range.
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the lowest version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    $Range = [SemVerRange]::new('>1.2.3')
+    $Range.MinSatisfying(@('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.4'
+    #>
+    [SemVer] MinSatisfying([SemVer[]]$versions) {
+        return [SemVerRange]::MinSatisfying($this, $versions)
+    }
+
+
+    <#
+    .SYNOPSIS
+    Get a lowest version in the list that satisfies the given range.
+
+    .PARAMETER range
+    The range for test
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the lowest version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    [SemVerRange]::MinSatisfying('>1.2.3', @('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.4'
+    #>
+    static [SemVer] MinSatisfying([SemVerRange]$range, [SemVer[]]$versions) {
+        $sortedVersions = ($versions | Sort-Object -Unique)
+
+        foreach ($v in $sortedVersions) {
+            if ($range.IsSatisfied($v)) {
+                return $v
+            }
+        }
+
+        return $null
+    }
+    #endregion <-- MinSatisfying() -->
+
+
+    #endregion <-- Satisfying() -->
+
+    <#
+    .SYNOPSIS
+    Get all versions in the list that satisfies this range.
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the all version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    $Range = [SemVerRange]::new('>1.2.3')
+    $Range.MinSatisfying(@('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.4' & '1.2.99'
+    #>
+    [SemVer[]] Satisfying([SemVer[]]$versions) {
+        return [SemVerRange]::Satisfying($this, $versions)
+    }
+
+    
+    <#
+    .SYNOPSIS
+    Get all versions in the list that satisfies the given range.
+
+    .PARAMETER range
+    The range for test
+
+    .PARAMETER versions
+    The list of versions to test
+
+    .RETURN
+    Returns the all version in the list that satisfies the range, or null if none of them do.
+
+    .EXAMPLE
+    [SemVerRange]::Satisfying('>1.2.3', @('1.2.0', '1.2.4', '1.2.99'))
+    # => returns '1.2.4' & '1.2.99'
+    #>
+    static [SemVer[]] Satisfying([SemVerRange]$range, [SemVer[]]$versions) {
+        return ($versions | Where-Object {$range.IsSatisfied($_)})
+    }
+    #endregion <-- Satisfying() -->
+
+}

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -659,7 +659,7 @@ Class SemVerRange {
     Return the range that intersects with all ranges.
 
     .EXAMPLE
-    [SemVerRange]::IntersectAll(@('>1.0.0', '<=2.0.0', '*')
+    [SemVerRange]::IntersectAll(@('>1.0.0', '<=2.0.0', '*'))
     #>
     static [SemVerRange] IntersectAll([SemVerRange[]]$ranges) {
         if ($ranges.Count -le 1) {

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -549,10 +549,9 @@ Class SemVerRange {
     #endregion <-- Satisfying() -->
 
 
-
     #region <-- Intersect() -->
 
-     <#
+    <#
     .SYNOPSIS
     Calculate the intersection between two ranges
 
@@ -568,11 +567,11 @@ Class SemVerRange {
     $RangeA.Intersect($rangeB)
     # => returns a new range that expressed for '>1.0.0 <=2.0.0'
     #>
-    [SemVerRange] Intersect([SemVerRange]$range){
+    [SemVerRange] Intersect([SemVerRange]$range) {
         return [SemVerRange]::Intersect($this, $range)
     }
 
-    
+
     <#
     .SYNOPSIS
     Calculate the intersection between two ranges
@@ -663,7 +662,7 @@ Class SemVerRange {
     [SemVerRange]::IntersectAll(@('>1.0.0', '<=2.0.0', '*')
     #>
     static [SemVerRange] IntersectAll([SemVerRange[]]$ranges) {
-        if($ranges.Count -le 1){
+        if ($ranges.Count -le 1) {
             return $ranges
         }
 

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -235,6 +235,7 @@ Class SemVerRange {
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
                     $this.IncludeMaximum = $true
                     $this.IncludeMinimum = $true
+                    $this.Expression = ('>={0}' -f [string]$this.MinimumVersion)
                 }
                 else {
                     $isError = $true
@@ -248,6 +249,7 @@ Class SemVerRange {
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
                     $this.IncludeMaximum = $true
                     $this.IncludeMinimum = $false
+                    $this.Expression = ('>{0}' -f [string]$this.MinimumVersion)
                 }
                 else {
                     $isError = $true
@@ -263,6 +265,7 @@ Class SemVerRange {
                     $this.MinimumVersion = [SemVer]::Min
                     $this.IncludeMaximum = $true
                     $this.IncludeMinimum = $true
+                    $this.Expression = ('<={0}' -f [string]$this.MaximumVersion)
                 }
                 else {
                     $isError = $true
@@ -276,6 +279,7 @@ Class SemVerRange {
                     $this.MinimumVersion = [SemVer]::Min
                     $this.IncludeMaximum = $false
                     $this.IncludeMinimum = $true
+                    $this.Expression = ('<{0}' -f [string]$this.MaximumVersion)
                 }
                 else {
                     $isError = $true

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -507,4 +507,18 @@ Class SemVerRange {
     }
     #endregion <-- Satisfying() -->
 
+
+    #region <-- ToString() -->
+    <#
+    .SYNOPSIS
+    Get the range expression string
+
+    .RETURN
+    Range expression string
+    #>
+    [string] ToString(){
+        return $this.Expression
+    }
+    #endregion <-- ToString() -->
+
 }

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -663,7 +663,7 @@ Class SemVerRange {
     #>
     static [SemVerRange] IntersectAll([SemVerRange[]]$ranges) {
         if ($ranges.Count -le 1) {
-            return $ranges
+            return $ranges[0]
         }
 
         [SemVerRange]$ret = $ranges[0]

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -47,7 +47,13 @@ Class SemVerRange {
     .SYNOPSIS
     Construct a new range that not matched any of versions (<0.0.0)
     #>
-    SemVerRange() {}
+    SemVerRange() {
+        $this.MaximumVersion = [Semver]::Min
+        $this.MinimumVersion = [Semver]::Min
+        $this.IncludeMinimum = $false
+        $this.IncludeMaximum = $false
+        $this.Expression = '<0.0.0'
+    }
 
 
     <#
@@ -115,6 +121,8 @@ Class SemVerRange {
         # All
         if (($expression -eq '') -or ($expression -eq '*')) {
             #empty or asterisk match all versions
+            $this.MaximumVersion = [SemVer]::Max
+            $this.MinimumVersion = [SemVer]::Min
             $this.Expression = '>=0.0.0'
         }
 
@@ -213,6 +221,7 @@ Class SemVerRange {
                 #Grater equals (e.g. '>=1.2.0'
                 $local:tempVersion = $expression.Substring(2)
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MaximumVersion = [SemVer]::Max
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
                     $this._IncludeMinimum = $true
                 }
@@ -224,6 +233,7 @@ Class SemVerRange {
                 #Grater than (e.g. '>1.2.0'
                 $local:tempVersion = $expression.Substring(1)
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
+                    $this.MaximumVersion = [SemVer]::Max
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
                     $this._IncludeMinimum = $false
                 }
@@ -238,7 +248,7 @@ Class SemVerRange {
                 $local:tempVersion = $expression.Substring(2)
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
                     $this.MaximumVersion = [SemVer]::Parse($tempVersion)
-                    $this._IncludeMaximum = $true
+                    $this.MinimumVersion = [SemVer]::Min
                 }
                 else {
                     $isError = $true

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -72,6 +72,35 @@ Class SemVerRange {
 
     <#
     .SYNOPSIS
+    Construct a new range from a min & max version
+
+    .PARAMETER minimum
+    The minimum version of a range
+
+    .PARAMETER maximum
+    The maximum version of a range
+
+    .PARAMETER includeMinimum
+    Whether or not to include the minimum version
+
+    .PARAMETER includeMaximum
+    Whether or not to include the maximum version
+    #>
+    SemVerRange([SemVer]$minimum, [SemVer]$maximum, [bool]$includeMinimum, [bool]$includeMaximum) {
+        $this.MaximumVersion = $maximum
+        $this.MinimumVersion = $minimum
+        $this._IncludeMinimum = $includeMinimum
+        $this._IncludeMaximum = $includeMaximum
+
+        if ($includeMinimum) {$operatorMin = '>='}else {$operatorMin = '>'}
+        if ($includeMaximum) {$operatorMax = '<='}else {$operatorMax = '<'}
+
+        $this.Expression = ('{2}{0} {3}{1}' -f [string]$minimum, [string]$maximum, $operatorMin, $operatorMax)
+    }
+
+
+    <#
+    .SYNOPSIS
     Construct a new range from range expression string
 
     .PARAMETER expression

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -37,9 +37,17 @@ Class SemVerRange {
     #>
     [string]$Expression = '<0.0.0'
 
-    # private properties
-    Hidden [bool]$_IncludeMaximum = $false
-    Hidden [bool]$_IncludeMinimum = $false
+    <#
+    .DESCRIPTION
+    Whether or not to include the maximum version
+    #>
+    [bool]$IncludeMaximum = $false
+
+    <#
+    .DESCRIPTION
+    Whether or not to include the minimum version
+    #>
+    [bool]$IncludeMinimum = $false
 
     #region <-- Constructor -->
 
@@ -69,8 +77,8 @@ Class SemVerRange {
     SemVerRange([SemVer]$minimum, [SemVer]$maximum) {
         $this.MaximumVersion = $maximum
         $this.MinimumVersion = $minimum
-        $this._IncludeMinimum = $true
-        $this._IncludeMaximum = $true
+        $this.IncludeMinimum = $true
+        $this.IncludeMaximum = $true
 
         $this.Expression = ('>={0} <={1}' -f [string]$minimum, [string]$maximum)
     }
@@ -95,8 +103,8 @@ Class SemVerRange {
     SemVerRange([SemVer]$minimum, [SemVer]$maximum, [bool]$includeMinimum, [bool]$includeMaximum) {
         $this.MaximumVersion = $maximum
         $this.MinimumVersion = $minimum
-        $this._IncludeMinimum = $includeMinimum
-        $this._IncludeMaximum = $includeMaximum
+        $this.IncludeMinimum = $includeMinimum
+        $this.IncludeMaximum = $includeMaximum
 
         if ($includeMinimum) {$operatorMin = '>='}else {$operatorMin = '>'}
         if ($includeMaximum) {$operatorMax = '<='}else {$operatorMax = '<'}
@@ -123,6 +131,8 @@ Class SemVerRange {
             #empty or asterisk match all versions
             $this.MaximumVersion = [SemVer]::Max
             $this.MinimumVersion = [SemVer]::Min
+            $this.IncludeMinimum = $true
+            $this.IncludeMaximum = $true
             $this.Expression = '>=0.0.0'
         }
 
@@ -168,8 +178,8 @@ Class SemVerRange {
 
                     $this.MaximumVersion = $max
                     $this.MinimumVersion = $min
-                    $this._IncludeMinimum = $true
-                    $this._IncludeMaximum = $false
+                    $this.IncludeMinimum = $true
+                    $this.IncludeMaximum = $false
             
                     $this.Expression = ('>={0} <{1}' -f [string]$min, [string]$max)
                 }
@@ -206,8 +216,8 @@ Class SemVerRange {
                 $minSemVer = [SemVer]::Parse([regex]::Replace($escape[0], '[xX\*]', '0') + '-' + $escape[1])
                 $this.MaximumVersion = $maxSemVer
                 $this.MinimumVersion = $minSemVer
-                $this._IncludeMinimum = $true
-                $this._IncludeMaximum = $false
+                $this.IncludeMinimum = $true
+                $this.IncludeMaximum = $false
 
                 $this.Expression = ('>={0} <{1}' -f [string]$minSemVer, [string]$maxSemVer)
             }
@@ -223,7 +233,8 @@ Class SemVerRange {
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
                     $this.MaximumVersion = [SemVer]::Max
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
-                    $this._IncludeMinimum = $true
+                    $this.IncludeMaximum = $true
+                    $this.IncludeMinimum = $true
                 }
                 else {
                     $isError = $true
@@ -235,7 +246,8 @@ Class SemVerRange {
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
                     $this.MaximumVersion = [SemVer]::Max
                     $this.MinimumVersion = [SemVer]::Parse($tempVersion)
-                    $this._IncludeMinimum = $false
+                    $this.IncludeMaximum = $true
+                    $this.IncludeMinimum = $false
                 }
                 else {
                     $isError = $true
@@ -249,6 +261,8 @@ Class SemVerRange {
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
                     $this.MaximumVersion = [SemVer]::Parse($tempVersion)
                     $this.MinimumVersion = [SemVer]::Min
+                    $this.IncludeMaximum = $true
+                    $this.IncludeMinimum = $true
                 }
                 else {
                     $isError = $true
@@ -259,7 +273,9 @@ Class SemVerRange {
                 $local:tempVersion = $expression.Substring(1)
                 if ([SemVer]::TryParse($tempVersion, [ref]$null)) {
                     $this.MaximumVersion = [SemVer]::Parse($tempVersion)
-                    $this._IncludeMaximum = $false
+                    $this.MinimumVersion = [SemVer]::Min
+                    $this.IncludeMaximum = $false
+                    $this.IncludeMinimum = $true
                 }
                 else {
                     $isError = $true
@@ -272,8 +288,8 @@ Class SemVerRange {
             #Specified strict version (e.g. '1.2.0'
             $this.MinimumVersion = [SemVer]::Parse($expression)
             $this.MaximumVersion = $this.MinimumVersion
-            $this._IncludeMinimum = $true
-            $this._IncludeMaximum = $true
+            $this.IncludeMinimum = $true
+            $this.IncludeMaximum = $true
             
             $this.Expression = [string]$this.MinimumVersion
         }
@@ -307,8 +323,8 @@ Class SemVerRange {
             $minSemVer = [SemVer]::Parse($min)
             $this.MaximumVersion = $maxSemVer
             $this.MinimumVersion = $minSemVer
-            $this._IncludeMinimum = $true
-            $this._IncludeMaximum = $false
+            $this.IncludeMinimum = $true
+            $this.IncludeMaximum = $false
 
             $this.Expression = ('>={0} <{1}' -f [string]$minSemVer, [string]$maxSemVer)
         }
@@ -354,7 +370,7 @@ Class SemVerRange {
         $ret = $true
 
         if ($range.MinimumVersion) {
-            if ($range._IncludeMinimum) {
+            if ($range.IncludeMinimum) {
                 $ret = $ret -and ($version -ge $range.MinimumVersion)
             }
 
@@ -364,7 +380,7 @@ Class SemVerRange {
         }
 
         if ($range.MaximumVersion) {
-            if ($range._IncludeMaximum) {
+            if ($range.IncludeMaximum) {
                 $ret = $ret -and ($version -le $range.MaximumVersion)
             }
 

--- a/Class/SemVerRange.ps1
+++ b/Class/SemVerRange.ps1
@@ -593,8 +593,8 @@ Class SemVerRange {
 
         [SemVer]$newMaximum = $null
         [SemVer]$newMinimum = $null
-        [bool]$newInculdeMax = $false
-        [bool]$newInculdeMin = $false
+        [bool]$newIncludeMax = $false
+        [bool]$newIncludeMin = $false
 
         # sort
         if ($range0.MaximumVersion -gt $range1.MaximumVersion) {
@@ -615,7 +615,7 @@ Class SemVerRange {
         if ($lower.MaximumVersion -eq $higher.MinimumVersion) {
             if ($lower.IncludeMaximum -and $higher.IncludeMinimum) {
                 $newMaximum = $lower.MaximumVersion
-                $newInculdeMax = $true
+                $newIncludeMax = $true
             }
             else {
                 return [SemVerRange]::new()
@@ -623,28 +623,28 @@ Class SemVerRange {
         }
         elseif ($lower.MaximumVersion -eq $higher.MaximumVersion) {
             $newMaximum = $lower.MaximumVersion
-            $newInculdeMax = ($lower.IncludeMaximum -and $higher.IncludeMinimum)
+            $newIncludeMax = ($lower.IncludeMaximum -and $higher.IncludeMinimum)
         }
         else {
             $newMaximum = $lower.MaximumVersion
-            $newInculdeMax = $lower.IncludeMaximum
+            $newIncludeMax = $lower.IncludeMaximum
         }
 
         # determine lower limit
         if ($higher.MinimumVersion -gt $lower.MinimumVersion) {
             $newMinimum = $higher.MinimumVersion
-            $newInculdeMin = $higher.IncludeMinimum
+            $newIncludeMin = $higher.IncludeMinimum
         }
         elseif ($higher.MinimumVersion -eq $lower.MinimumVersion) {
             $newMinimum = $higher.MinimumVersion
-            $newInculdeMin = ($higher.IncludeMinimum -and $lower.IncludeMinimum)
+            $newIncludeMin = ($higher.IncludeMinimum -and $lower.IncludeMinimum)
         }
         else {
             $newMinimum = $lower.MinimumVersion
-            $newInculdeMin = $lower.IncludeMinimum
+            $newIncludeMin = $lower.IncludeMinimum
         }
     
-        return [SemVerRange]::new($newMinimum, $newMaximum, $newInculdeMin, $newInculdeMax)
+        return [SemVerRange]::new($newMinimum, $newMaximum, $newIncludeMin, $newIncludeMax)
     }
 
 

--- a/pspm.psm1
+++ b/pspm.psm1
@@ -13,7 +13,7 @@ $Classist = @(
 $Classist | foreach {
     . (Join-Path (Join-Path $modulePath $classPath) $_)
 }
-#endregion Load functions
+#endregion Load classes
 
 #region Load functions
 $FunctionList = @(

--- a/pspm.psm1
+++ b/pspm.psm1
@@ -1,7 +1,19 @@
 #Requires -Version 4
 
 $modulePath = $PSScriptRoot
+$classPath = '/Class'
 $functionsPath = '/functions'
+
+#region Load classes
+$Classist = @(
+    'SemVer.ps1'
+    'SemVerRange.ps1'
+)
+
+$Classist | foreach {
+    . (Join-Path (Join-Path $modulePath $classPath) $_)
+}
+#endregion Load functions
 
 #region Load functions
 $FunctionList = @(


### PR DESCRIPTION
* Implement union range (`1.2.7 || >=1.2.9`) (#33)
* Implement intersection (`>=1.2.7 <1.3.0`) (#32)
* Implement X-Range (`1.2.x`)
* Implement Tilde-Range (`~1.2.3`)
* Implement Caret-Range (`^0.2.3`)
* Fix #37
* pspm install実行時、既に指定バージョンを満たすモジュールが`Modules`フォルダに存在する場合は最新バージョン取得処理をスキップするように変更